### PR TITLE
Add Prometheus metrics info to docs

### DIFF
--- a/docs/topics/installation.md
+++ b/docs/topics/installation.md
@@ -38,6 +38,21 @@ make -C /usr/ports/databases/tile38 install
 
 Tile38 has pre-built release binaries for OSX, Linux, FreeBSD, and Windows. Instructions for using these binaries are on the GitHub [releases page](https://github.com/tidwall/tile38/releases).
 
+
+## Prometheus Metrics
+Tile38 can natively export Prometheus metrics by setting the `--metrics-addr` command line flag (disabled by default). This example exposes the HTTP metrics server on port 4321:
+```plaintext
+# start server and enable Prometheus metrics, listen on local interface only
+./tile38-server --metrics-addr=127.0.0.1:4321
+# access metrics
+curl http://127.0.0.1:4321/metrics
+```
+If you need to access the `/metrics` endpoint from a different host you'll have to set the flag accordingly, e.g. set it to `0.0.0.0:<<port>>` to listen on all interfaces.
+
+Use the [redis_exporter](https://github.com/oliver006/redis_exporter) for more advanced use cases like extracting key values or running a lua script.
+
+
+
 # Next steps
 
 If not already started, start the Tile38 with:


### PR DESCRIPTION
Follow up from https://github.com/tidwall/tile38/pull/604

@tidwall - I took the exact same blurb we added to the README - let me if you prefer something different for the docs.