### PR TITLE
docs: add HEALTHZ to commands.json

### DIFF
--- a/website/static/json/commands.json
+++ b/website/static/json/commands.json
@@ -1222,6 +1222,12 @@
     "since": "1.0.0",
     "group": "server"
   },
+  "HEALTHZ": {
+    "summary": "Healthchecks on leader and follower",
+    "arguments": [],
+    "since": "1.0.0",
+    "group": "server"
+  },
   "GC": {
     "summary": "Forces a garbage collection",
     "complexity": "O(1)",


### PR DESCRIPTION
looks like it's missing from here and is therefore not shown on the website under /commands.